### PR TITLE
Implementation of Capture's CAEX Layer

### DIFF
--- a/citp.lua
+++ b/citp.lua
@@ -143,6 +143,12 @@ function citp_proto.dissector(buffer,pinfo,tree)
         subtree:add("Feed " .. (i) .. ": " .. str)
         feedNameStart = feedNameStart + l
       end
+	  
+    elseif str == "Laser Feed Frame" then
+      subtree:add( string.format("Source Key: 0x%08x", buffer(24,4):le_uint())) 
+      subtree:add( "Feed Index: " .. buffer(28,1):le_uint())
+	  subtree:add( "Frame Seq Num: " .. buffer(29,4):le_uint())
+	  subtree:add( "Point Count: " .. buffer(33,2):le_uint())
     end
   
   end

--- a/citp.lua
+++ b/citp.lua
@@ -34,7 +34,9 @@ ct = {
   GELI = "Get Element Library Information message",
   GELT = "Get Element Library Thumbnail message",
   GVSr = "GetVideoSources",
-  VSrc = "Video Sources"
+  VSrc = "Video Sources",
+    -- Other
+  CAEX = "Capture Extensions"
 }
 
 lt = {
@@ -86,6 +88,15 @@ function citp_proto.dissector(buffer,pinfo,tree)
   if message_size > buffer:len() then
     pinfo.desegment_len = message_size - buffer:len()
     return
+  end
+  
+  -- CAEX ------------------------------------------------------------------------
+  -- Capture CITP Extensions
+  if buffer(16,4):string() == "CAEX" then
+    pinfo.cols.info:append ("CAEX >")   -- info
+    str = ct[buffer(20,4):string()] or "(Unknown)"
+    subtree:add(buffer(20,4), "Content Type: " .. buffer(20,4):string() .. " - " ..str)
+
   end
 
   -- PINF ------------------------------------------------------------------------

--- a/citp.lua
+++ b/citp.lua
@@ -102,6 +102,7 @@ function citp_proto.dissector(buffer,pinfo,tree)
   -- PINF ------------------------------------------------------------------------
   -- Peer Information layer
   if buffer(16,4):string() == "PINF" then
+    name=""
     pinfo.cols.info:append ("PINF >")   -- info
     str = ct[buffer(20,4):string()] or "(Unknown)"
     subtree:add(buffer(20,4), "Content Type: " .. buffer(20,4):string() .. " - " ..str)
@@ -113,10 +114,9 @@ function citp_proto.dissector(buffer,pinfo,tree)
       pinfo.cols.info:append ("PNam >")   -- info
       count = string.find(buffer(start):string(),"\0",1)
       subtree:add(buffer(start, count),"Name: ".. buffer(start):string())
-    end
 
     --PLoc
-    if buffer(20,4):string() == "PLoc" then
+    elseif buffer(20,4):string() == "PLoc" then
       pinfo.cols.info:append ("PLoc >")   -- info
       listeningport = buffer(24,2):le_uint()
       subtree:add(buffer(24,2), "Listening Port: " .. (listeningport))
@@ -139,7 +139,9 @@ function citp_proto.dissector(buffer,pinfo,tree)
       start = start+count
       count = string.find(buffer(start):string(),"\0",1)
       subtree:add(buffer(start, count),"State: ".. buffer(start):string())
-    end
+    else
+	  pinfo.cols.info:append ("Unknown format or content type")
+	end
     pinfo.cols.info:append (name)   -- info
   end
 

--- a/citp.lua
+++ b/citp.lua
@@ -145,10 +145,17 @@ function citp_proto.dissector(buffer,pinfo,tree)
       end
 	  
     elseif str == "Laser Feed Frame" then
+      pinfo.cols.info:append (" >Feed " .. buffer(28,1):le_uint())
       subtree:add( string.format("Source Key: 0x%08x", buffer(24,4):le_uint())) 
       subtree:add( "Feed Index: " .. buffer(28,1):le_uint())
 	  subtree:add( "Frame Seq Num: " .. buffer(29,4):le_uint())
 	  subtree:add( "Point Count: " .. buffer(33,2):le_uint())
+	  
+    elseif str == "Laser Feed Control" then
+      pinfo.cols.info:append (" >Feed " .. buffer(24,1):le_uint())
+      subtree:add( "Feed Index: " .. buffer(24,1):le_uint())
+	  subtree:add( "Framerate: " .. buffer(25,1):le_uint())
+
     end
   
   end


### PR DESCRIPTION
These changes allow the dissector to recognize all of Capture's CAEX layer content codes for Live Views, Cue Recording, Show Synchronization, and Laser Feeds.  

Currently only Laser feed messages are further dissected.

The capture CAEX layer is documented here: http://www.capturesweden.com/Support/Developers
Direct PDF: http://www.capturesweden.com/Portals/0/Downloads/CITP%20CAEX%20Specification%20E.pdf?ver=2018-07-27-133641-930

I have not done a lot of real world testing as yet, but the dissection should be fairly straight forward.